### PR TITLE
setup SqlGuard, prev. version lived in rdb

### DIFF
--- a/guard/api/pom.xml
+++ b/guard/api/pom.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<!--
+/*********************************************************************
+* Copyright (c) 2024 Contributors to the Eclipse Foundation.
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which is available at https://www.eclipse.org/legal/epl-2.0/
+*
+* SPDX-License-Identifier: EPL-2.0
+**********************************************************************/
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.eclipse.daanse</groupId>
+    <artifactId>org.eclipse.daanse.sql.guard</artifactId>
+    <version>${revision}</version>
+  </parent>
+  <artifactId>org.eclipse.daanse.sql.guard.api</artifactId>
+
+
+</project>

--- a/guard/api/src/main/java/org/eclipse/daanse/sql/guard/api/SqlGuard.java
+++ b/guard/api/src/main/java/org/eclipse/daanse/sql/guard/api/SqlGuard.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   SmartCity Jena - initial
+ *   Stefan Bischof (bipolis.org) - initial
+ */
+package org.eclipse.daanse.sql.guard.api;
+
+import org.eclipse.daanse.sql.guard.api.exception.GuardException;
+
+public interface SqlGuard {
+
+    String guard(String sql) throws GuardException;
+
+}

--- a/guard/api/src/main/java/org/eclipse/daanse/sql/guard/api/SqlGuardFactory.java
+++ b/guard/api/src/main/java/org/eclipse/daanse/sql/guard/api/SqlGuardFactory.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   SmartCity Jena - initial
+ *   Stefan Bischof (bipolis.org) - initial
+ */
+package org.eclipse.daanse.sql.guard.api;
+
+import org.eclipse.daanse.sql.guard.api.elements.DatabaseCatalog;
+
+public interface SqlGuardFactory {
+
+    SqlGuard create(String currentCatalogName, String currentSchemaName, DatabaseCatalog databaseCatalog);
+}

--- a/guard/api/src/main/java/org/eclipse/daanse/sql/guard/api/elements/DatabaseCatalog.java
+++ b/guard/api/src/main/java/org/eclipse/daanse/sql/guard/api/elements/DatabaseCatalog.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   SmartCity Jena - initial
+ *   Stefan Bischof (bipolis.org) - initial
+ */
+package org.eclipse.daanse.sql.guard.api.elements;
+
+import java.util.List;
+
+public interface DatabaseCatalog {
+
+    String getName();
+
+    List<DatabaseSchema> getDatabaseSchemas();
+}

--- a/guard/api/src/main/java/org/eclipse/daanse/sql/guard/api/elements/DatabaseColumn.java
+++ b/guard/api/src/main/java/org/eclipse/daanse/sql/guard/api/elements/DatabaseColumn.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   SmartCity Jena - initial
+ *   Stefan Bischof (bipolis.org) - initial
+ */
+package org.eclipse.daanse.sql.guard.api.elements;
+
+public interface DatabaseColumn {
+
+    String getName();
+
+}

--- a/guard/api/src/main/java/org/eclipse/daanse/sql/guard/api/elements/DatabaseSchema.java
+++ b/guard/api/src/main/java/org/eclipse/daanse/sql/guard/api/elements/DatabaseSchema.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   SmartCity Jena - initial
+ *   Stefan Bischof (bipolis.org) - initial
+ */
+package org.eclipse.daanse.sql.guard.api.elements;
+
+import java.util.List;
+
+public interface DatabaseSchema {
+
+    String getName();
+
+    List<DatabaseTable> getDatabaseTables();
+}

--- a/guard/api/src/main/java/org/eclipse/daanse/sql/guard/api/elements/DatabaseTable.java
+++ b/guard/api/src/main/java/org/eclipse/daanse/sql/guard/api/elements/DatabaseTable.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   SmartCity Jena - initial
+ *   Stefan Bischof (bipolis.org) - initial
+ */
+package org.eclipse.daanse.sql.guard.api.elements;
+
+import java.util.List;
+
+public interface DatabaseTable {
+
+    String getName();
+
+    List<DatabaseColumn> getDatabaseColumns();
+}

--- a/guard/api/src/main/java/org/eclipse/daanse/sql/guard/api/elements/package-info.java
+++ b/guard/api/src/main/java/org/eclipse/daanse/sql/guard/api/elements/package-info.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   SmartCity Jena - initial
+ *   Stefan Bischof (bipolis.org) - initial
+ */
+
+@org.osgi.annotation.bundle.Export
+@org.osgi.annotation.versioning.Version("0.0.1")
+package org.eclipse.daanse.sql.guard.api.elements;

--- a/guard/api/src/main/java/org/eclipse/daanse/sql/guard/api/exception/EmptyStatementGuardException.java
+++ b/guard/api/src/main/java/org/eclipse/daanse/sql/guard/api/exception/EmptyStatementGuardException.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   SmartCity Jena - initial
+ *   Stefan Bischof (bipolis.org) - initial
+ */
+package org.eclipse.daanse.sql.guard.api.exception;
+
+public class EmptyStatementGuardException extends GuardException {
+
+    private static final long serialVersionUID = 1L;
+
+    public EmptyStatementGuardException() {
+        this("The provided Statement must not be empty.");
+    }
+
+    private EmptyStatementGuardException(String message) {
+
+        super(message);
+    }
+
+}

--- a/guard/api/src/main/java/org/eclipse/daanse/sql/guard/api/exception/GuardException.java
+++ b/guard/api/src/main/java/org/eclipse/daanse/sql/guard/api/exception/GuardException.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   SmartCity Jena - initial
+ *   Stefan Bischof (bipolis.org) - initial
+ */
+package org.eclipse.daanse.sql.guard.api.exception;
+
+public class GuardException extends Exception {
+
+    private static final long serialVersionUID = 1L;
+
+    public GuardException() {
+
+    }
+
+    public GuardException(String message) {
+        super(message);
+    }
+
+}

--- a/guard/api/src/main/java/org/eclipse/daanse/sql/guard/api/exception/UnallowedStatementTypeGuardException.java
+++ b/guard/api/src/main/java/org/eclipse/daanse/sql/guard/api/exception/UnallowedStatementTypeGuardException.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   SmartCity Jena - initial
+ *   Stefan Bischof (bipolis.org) - initial
+ */
+package org.eclipse.daanse.sql.guard.api.exception;
+
+public class UnallowedStatementTypeGuardException extends GuardException {
+
+    private static final long serialVersionUID = 1L;
+
+    public UnallowedStatementTypeGuardException(String message) {
+
+        super(message);
+    }
+
+}

--- a/guard/api/src/main/java/org/eclipse/daanse/sql/guard/api/exception/UnparsableStatementGuardException.java
+++ b/guard/api/src/main/java/org/eclipse/daanse/sql/guard/api/exception/UnparsableStatementGuardException.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   SmartCity Jena - initial
+ *   Stefan Bischof (bipolis.org) - initial
+ */
+package org.eclipse.daanse.sql.guard.api.exception;
+
+public class UnparsableStatementGuardException extends GuardException {
+
+    private static final long serialVersionUID = 1L;
+
+    public UnparsableStatementGuardException() {
+        this("Statement could not be parsed");
+    }
+
+    private UnparsableStatementGuardException(String message) {
+
+        super(message);
+    }
+
+}

--- a/guard/api/src/main/java/org/eclipse/daanse/sql/guard/api/exception/UnresolvableObjectsGuardException.java
+++ b/guard/api/src/main/java/org/eclipse/daanse/sql/guard/api/exception/UnresolvableObjectsGuardException.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   SmartCity Jena - initial
+ *   Stefan Bischof (bipolis.org) - initial
+ */
+package org.eclipse.daanse.sql.guard.api.exception;
+
+import java.util.Set;
+
+public class UnresolvableObjectsGuardException extends GuardException {
+
+    private static final long serialVersionUID = 1L;
+    private Set<String> unresolvedObjects;
+
+    public UnresolvableObjectsGuardException(String message) {
+
+        super(message);
+    }
+
+    public Set<String> getUnresolvedObjects() {
+        return unresolvedObjects;
+    }
+
+}

--- a/guard/api/src/main/java/org/eclipse/daanse/sql/guard/api/exception/package-info.java
+++ b/guard/api/src/main/java/org/eclipse/daanse/sql/guard/api/exception/package-info.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   SmartCity Jena - initial
+ *   Stefan Bischof (bipolis.org) - initial
+ */
+
+@org.osgi.annotation.bundle.Export
+@org.osgi.annotation.versioning.Version("0.0.1")
+package org.eclipse.daanse.sql.guard.api.exception;

--- a/guard/api/src/main/java/org/eclipse/daanse/sql/guard/api/package-info.java
+++ b/guard/api/src/main/java/org/eclipse/daanse/sql/guard/api/package-info.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   SmartCity Jena - initial
+ *   Stefan Bischof (bipolis.org) - initial
+ */
+
+@org.osgi.annotation.bundle.Export
+@org.osgi.annotation.versioning.Version("0.0.1")
+package org.eclipse.daanse.sql.guard.api;

--- a/guard/jsqltranspiler/pom.xml
+++ b/guard/jsqltranspiler/pom.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0"?>
+<!--
+/*********************************************************************
+* Copyright (c) 2024 Contributors to the Eclipse Foundation.
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which is available at https://www.eclipse.org/legal/epl-2.0/
+*
+* SPDX-License-Identifier: EPL-2.0
+**********************************************************************/
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.eclipse.daanse</groupId>
+    <artifactId>org.eclipse.daanse.sql.guard</artifactId>
+    <version>${revision}</version>
+  </parent>
+  <artifactId>org.eclipse.daanse.sql.guard.jsqltranspiler</artifactId>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.eclipse.daanse</groupId>
+      <artifactId>org.eclipse.daanse.sql.guard.api</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.github.jsqlparser</groupId>
+      <artifactId>jsqlparser</artifactId>
+      <version>5.2-SNAPSHOT</version>
+    </dependency>
+    <dependency>
+      <groupId>ai.starlake.jsqltranspiler</groupId>
+      <artifactId>jsqltranspiler</artifactId>
+      <version>0.7-SNAPSHOT</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/guard/jsqltranspiler/src/main/java/org/eclipse/daanse/sql/guard/jsqltranspiler/TranspilerSqlGuard.java
+++ b/guard/jsqltranspiler/src/main/java/org/eclipse/daanse/sql/guard/jsqltranspiler/TranspilerSqlGuard.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   SmartCity Jena - initial
+ *   Stefan Bischof (bipolis.org) - initial
+ */
+
+package org.eclipse.daanse.sql.guard.jsqltranspiler;
+
+import java.util.List;
+import java.util.Set;
+
+import org.eclipse.daanse.sql.guard.api.SqlGuard;
+import org.eclipse.daanse.sql.guard.api.elements.DatabaseCatalog;
+import org.eclipse.daanse.sql.guard.api.elements.DatabaseSchema;
+import org.eclipse.daanse.sql.guard.api.elements.DatabaseTable;
+import org.eclipse.daanse.sql.guard.api.exception.EmptyStatementGuardException;
+import org.eclipse.daanse.sql.guard.api.exception.GuardException;
+import org.eclipse.daanse.sql.guard.api.exception.UnallowedStatementTypeGuardException;
+import org.eclipse.daanse.sql.guard.api.exception.UnparsableStatementGuardException;
+import org.eclipse.daanse.sql.guard.api.exception.UnresolvableObjectsGuardException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import ai.starlake.transpiler.CatalogNotFoundException;
+import ai.starlake.transpiler.ColumnNotFoundException;
+import ai.starlake.transpiler.JSQLColumResolver;
+import ai.starlake.transpiler.JSQLResolver;
+import ai.starlake.transpiler.SchemaNotFoundException;
+import ai.starlake.transpiler.TableNotDeclaredException;
+import ai.starlake.transpiler.TableNotFoundException;
+import ai.starlake.transpiler.schema.JdbcColumn;
+import ai.starlake.transpiler.schema.JdbcMetaData;
+import net.sf.jsqlparser.JSQLParserException;
+import net.sf.jsqlparser.expression.Expression;
+import net.sf.jsqlparser.parser.CCJSqlParserUtil;
+import net.sf.jsqlparser.statement.Statement;
+import net.sf.jsqlparser.statement.select.Select;
+import net.sf.jsqlparser.util.deparser.StatementDeParser;
+
+public class TranspilerSqlGuard implements SqlGuard {
+
+    private static final String DELETE_IS_NOT_PERMITTED = "DELETE is not permitted.";
+    private static final String UPDATE_IS_NOT_PERMITTED = "UPDATE is not permitted.";
+    private static final String INSERT_IS_NOT_PERMITTED = "INSERT is not permitted.";
+    private static final String NOTHING_WAS_SELECTED = "Nothing was selected.";
+    private static final Logger LOGGER = LoggerFactory.getLogger(TranspilerSqlGuard.class);
+    private JdbcMetaData jdbcMetaDataToCopy;
+
+    public TranspilerSqlGuard(String currentCatalogName, String currentSchemaName, DatabaseCatalog databaseCatalog) {
+
+        jdbcMetaDataToCopy = calculateMetaData(currentCatalogName, currentSchemaName, databaseCatalog);
+
+    }
+
+    @Override
+    public String guard(String sqlStr) throws GuardException {
+
+        LOGGER.atInfo().log("guard incoming: %s", sqlStr);
+        StringBuilder builder = new StringBuilder();
+        StatementDeParser deParser = new StatementDeParser(builder);
+
+        JSQLResolver resolver = new JSQLResolver(jdbcMetaDataToCopy);
+
+        // this does not really work, when there are comments
+        // @todo: apply a Regex for SQL Comments
+        if (sqlStr == null || sqlStr.trim().isEmpty()) {
+            throw new EmptyStatementGuardException();
+        }
+
+        try {
+            Statement st = CCJSqlParserUtil.parse(sqlStr);
+
+            // we can test for SELECT, though in practise it won't protect us from harmful statements
+            if (st instanceof Select) {
+                resolver.resolve(st);
+
+                // select columns should not be empty
+                final List<JdbcColumn> selectColumns = resolver.getSelectColumns();
+                if (selectColumns.isEmpty()) {
+                    LOGGER.atInfo().log(NOTHING_WAS_SELECTED);
+                    throw new GuardException(NOTHING_WAS_SELECTED);
+                }
+
+                // any delete columns must be empty
+                final List<JdbcColumn> deleteColumns = resolver.getDeleteColumns();
+                if (!deleteColumns.isEmpty()) {
+                    LOGGER.atInfo().log(DELETE_IS_NOT_PERMITTED);
+                    throw new GuardException(DELETE_IS_NOT_PERMITTED);
+                }
+
+                // any update columns must be empty
+                final List<JdbcColumn> updateColumns = resolver.getUpdateColumns();
+                if (!updateColumns.isEmpty()) {
+                    LOGGER.atInfo().log(UPDATE_IS_NOT_PERMITTED);
+                    throw new GuardException(UPDATE_IS_NOT_PERMITTED);
+                }
+
+                // any insert columns must be empty
+                final List<JdbcColumn> insertColumns = resolver.getInsertColumns();
+                if (!insertColumns.isEmpty()) {
+                    LOGGER.atInfo().log(INSERT_IS_NOT_PERMITTED);
+                    throw new GuardException(INSERT_IS_NOT_PERMITTED);
+                }
+
+                // check functions
+                final List<Expression> functions = resolver.getFunctions();
+                final Set<String> functionNames = resolver.getFlatFunctionNames();
+
+                // we can finally resolve for the actually returned columns
+                JSQLColumResolver columResolver = new JSQLColumResolver(jdbcMetaDataToCopy);
+                columResolver.setErrorMode(JdbcMetaData.ErrorMode.STRICT);
+
+                String rewritten = columResolver.getResolvedStatementText(sqlStr);
+                // TODO: get it as object and access to AST that we do not have to reparse
+                Statement stResolveds = CCJSqlParserUtil.parse(rewritten);
+
+                // TODO: check the count of functions and deepnes and size of statement. we should be able check on
+                // this variables if we allow statement or if it calls to much.
+
+                deParser.visit((Select) st);// or rewritten
+
+                LOGGER.atInfo().log("guard outgoin: %s", rewritten);
+
+                return rewritten;
+
+            } else {
+                throw new UnallowedStatementTypeGuardException(
+                        st.getClass().getSimpleName().toUpperCase() + " is not permitted.");
+            }
+        }
+
+        catch (JSQLParserException ex) {
+            throw new UnparsableStatementGuardException();
+        } catch (CatalogNotFoundException | ColumnNotFoundException | SchemaNotFoundException
+                | TableNotDeclaredException | TableNotFoundException ex) {
+            throw new UnresolvableObjectsGuardException(ex.getMessage());
+        }
+
+    }
+
+    private static JdbcMetaData calculateMetaData(String currentCatalogName, String currentSchemaName,
+            DatabaseCatalog databaseCatalog) {
+        JdbcMetaData jdbcMetaData = new JdbcMetaData(currentCatalogName, currentSchemaName);
+
+        for (DatabaseSchema schema : databaseCatalog.getDatabaseSchemas()) {
+            for (DatabaseTable table : schema.getDatabaseTables()) {
+
+                List<JdbcColumn> jdbcColumns = table.getDatabaseColumns().parallelStream()
+                        .map(c -> new JdbcColumn(c.getName())).toList();
+                jdbcMetaData.addTable(schema.getName(), table.getName(), jdbcColumns);
+            }
+        }
+        return jdbcMetaData;
+    }
+
+}

--- a/guard/jsqltranspiler/src/main/java/org/eclipse/daanse/sql/guard/jsqltranspiler/TranspilerSqlGuardFactory.java
+++ b/guard/jsqltranspiler/src/main/java/org/eclipse/daanse/sql/guard/jsqltranspiler/TranspilerSqlGuardFactory.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   SmartCity Jena - initial
+ *   Stefan Bischof (bipolis.org) - initial
+ */
+package org.eclipse.daanse.sql.guard.jsqltranspiler;
+
+import org.eclipse.daanse.sql.guard.api.SqlGuard;
+import org.eclipse.daanse.sql.guard.api.SqlGuardFactory;
+import org.eclipse.daanse.sql.guard.api.elements.DatabaseCatalog;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ServiceScope;
+
+@Component(scope = ServiceScope.SINGLETON)
+public class TranspilerSqlGuardFactory implements SqlGuardFactory {
+
+    @Override
+    public SqlGuard create(String currentCatalogName, String currentSchemaName, DatabaseCatalog databaseCatalog) {
+        return new TranspilerSqlGuard(currentCatalogName, currentSchemaName, databaseCatalog);
+    }
+
+}

--- a/guard/jsqltranspiler/src/main/java/org/eclipse/daanse/sql/guard/jsqltranspiler/package-info.java
+++ b/guard/jsqltranspiler/src/main/java/org/eclipse/daanse/sql/guard/jsqltranspiler/package-info.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   SmartCity Jena - initial
+ *   Stefan Bischof (bipolis.org) - initial
+ */
+package org.eclipse.daanse.sql.guard.jsqltranspiler;

--- a/guard/jsqltranspiler/src/test/java/org/eclipse/daanse/sql/guard/jsqltranspiler/SqlGuardTest.java
+++ b/guard/jsqltranspiler/src/test/java/org/eclipse/daanse/sql/guard/jsqltranspiler/SqlGuardTest.java
@@ -1,0 +1,365 @@
+/*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   SmartCity Jena - initial
+ *   Stefan Bischof (bipolis.org) - initial
+ */
+
+package org.eclipse.daanse.sql.guard.jsqltranspiler;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import org.eclipse.daanse.sql.guard.api.SqlGuard;
+import org.eclipse.daanse.sql.guard.api.SqlGuardFactory;
+import org.eclipse.daanse.sql.guard.api.elements.DatabaseCatalog;
+import org.eclipse.daanse.sql.guard.api.elements.DatabaseColumn;
+import org.eclipse.daanse.sql.guard.api.elements.DatabaseSchema;
+import org.eclipse.daanse.sql.guard.api.elements.DatabaseTable;
+import org.eclipse.daanse.sql.guard.api.exception.UnresolvableObjectsGuardException;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.osgi.test.common.annotation.InjectService;
+
+public class SqlGuardTest {
+
+    private static final String FOO_FACT = "fooFact";
+
+    private static final String VALUE = "value";
+
+    private static final String FOO = "foo";
+
+    private static final String NAME = "name";
+
+    private static final String ID = "id";
+
+    private static final String SCH = "sch";
+
+    private static final String SQL_WITH_FUNCTION_WRONG_COLUMN = "select trim(foo.name1)  from foo";
+
+    private static final String SQL_WITH_FUNCTION_WRONG_TABLE = "select trim(foo1.name)  from foo";
+
+    private static final String SQL_WITH_FUNCTION = "select trim(foo.name)  from foo";
+
+    private static final String SQL_WITH_FUNCTION_EXPECTED = "SELECT Trim( foo.name ) FROM sch.foo";
+
+    private static final String SQL_WITH_HAVING_WRONG_COLUMN = """
+            select %s(foo.id) from foo group by foo.name having foo.name1 = 'tets'""";
+
+    private static final String SQL_WITH_HAVING_WRONG_TABLE1 = """
+            select %s(foo.id) from foo group by foo.name having foo1.name = 'tets'""";
+
+    private static final String SQL_WITH_HAVING1 = """
+            select %s(foo.id) from foo group by foo.name having foo.name = 'tets'""";
+
+    private static final String SQL_WITH_HAVING1_EXPECTED = """
+            SELECT %s(foo.id) FROM sch.foo GROUP BY foo.name HAVING foo.name = 'tets'""";
+
+    private static final String SQL_WITH_HAVING = """
+            select %s(foo.id) from foo group by foo.name having %s(foo.id) > 5""";
+
+    private static final String SQL_WITH_HAVING_EXPECTED = """
+            SELECT %s(foo.id) FROM sch.foo GROUP BY foo.name HAVING %s(foo.id) > 5""";
+
+    private static final String SQL_WITH_HAVING_WRONG_TABLE = """
+            select %s(foo.id) from foo group by foo.name having %s(foo1.id) > 5""";
+
+    private static final String SQL_WITH_AGG_WITH_WRONG_TABLE = """
+            select %s(foo1.id) from foo group by foo.name""";
+
+    private static final String SQL_WITH_AGG = """
+            select %s(foo.id)  from foo group by foo.name""";
+
+    private static final String SQL_WITH_AGG_EXPECTED = """
+            SELECT %s(foo.id) FROM sch.foo GROUP BY foo.name""";
+
+    private static final String SQL_WITH_GROUP = "select * from foo group by foo.id, foo.name";
+
+    private static final String SQL_WITH_GROUP_EXPECTED = """
+            SELECT sch.foo.id /* Resolved Column*/ , sch.foo.name /* Resolved Column*/  FROM sch.foo GROUP BY foo.id, foo.name""";
+
+    private static final String TABLE_FOO1_DOES_NOT_EXIST_IN_THE_GIVEN_SCHEMA_SCH = "Table foo1 does not exist in the given Schema sch";
+
+    private static final String SIMPLE_SQL_WITH_WRONG_TABLE = "select * from foo1";
+
+    private static final String SQL_WITH_WRONG_TABLE = """
+            select * from foo where foo.id in (select fooFact1.id from fooFact1)
+                """;
+
+    private static final String SQL_WITH_CUSTOM_COLUMN = """
+            select *, 5 as testColumn from foo where foo.id  = 10""";
+
+    private static final String SQL_WITH_CUSTOM_COLUMN_EXPECTED = """
+            SELECT sch.foo.id /* Resolved Column*/ , sch.foo.name /* Resolved Column*/ , 5 AS testColumn FROM sch.foo WHERE foo.id = 10""";
+
+    private static final String SQL_WITH_IN = """
+            select * from foo where foo.id in (select fooFact.id from fooFact)""";
+
+    private static final String SQL_WITH_IN_EXPECTED = """
+            SELECT sch.foo.id /* Resolved Column*/ , sch.foo.name /* Resolved Column*/  FROM sch.foo WHERE foo.id IN (SELECT fooFact.id FROM fooFact)""";
+
+    private static final String TRIPLE_SELECT_SQL = """
+            SELECT * FROM ( SELECT * FROM ( SELECT * FROM foo inner join fooFact on foo.id = fooFact.id ) a ) b""";
+
+    private static final String TRIPLE_SELECT_SQL_EXPECTED = """
+            SELECT sch.b.id /* Resolved Column*/ , sch.b.name /* Resolved Column*/ , sch.b.id_1 /* Resolved Column*/ , sch.b.value /* Resolved Column*/  FROM (SELECT sch.a.id /* Resolved Column*/ , sch.a.name /* Resolved Column*/ , sch.a.id_1 /* Resolved Column*/ , sch.a.value /* Resolved Column*/  FROM (SELECT sch.foo.id /* Resolved Column*/ , sch.foo.name /* Resolved Column*/ , sch.fooFact.id /* Resolved Column*/ , sch.fooFact.value /* Resolved Column*/  FROM sch.foo INNER JOIN sch.fooFact ON foo.id = fooFact.id) a) b""";
+
+    private static final String SELECT_INNER_JOIN_C_D = """
+            SELECT * FROM ((SELECT * FROM foo) c inner join fooFact on c.id = fooFact.id ) d""";
+
+    private static final String SELECT_INNER_JOIN_C_D_EXPECTED = """
+            SELECT sch.d.id /* Resolved Column*/ , sch.d.name /* Resolved Column*/ , sch.d.id_1 /* Resolved Column*/ , sch.d.value /* Resolved Column*/  FROM ((SELECT sch.foo.id /* Resolved Column*/ , sch.foo.name /* Resolved Column*/  FROM sch.foo) c INNER JOIN sch.fooFact ON c.id = fooFact.id) d""";
+
+    private static final String SELECT_INNER_JOIN_D = """
+            SELECT * FROM ( SELECT * FROM foo inner join fooFact on foo.id = fooFact.id ) d""";
+
+    private static final String SELECT_INNER_JOIN_D_EXPECTED = """
+            SELECT sch.d.id /* Resolved Column*/ , sch.d.name /* Resolved Column*/ , sch.d.id_1 /* Resolved Column*/ , sch.d.value /* Resolved Column*/  FROM (SELECT sch.foo.id /* Resolved Column*/ , sch.foo.name /* Resolved Column*/ , sch.fooFact.id /* Resolved Column*/ , sch.fooFact.value /* Resolved Column*/  FROM sch.foo INNER JOIN sch.fooFact ON foo.id = fooFact.id) d""";
+
+    private static final String SELECT_INNER_JOIN = """
+            select * from foo inner join fooFact on foo.id = fooFact.id""";
+
+    private static final String SELECT_INNER_JOIN_EXPECTED = """
+            SELECT sch.foo.id /* Resolved Column*/ , sch.foo.name /* Resolved Column*/ , sch.fooFact.id /* Resolved Column*/ , sch.fooFact.value /* Resolved Column*/  FROM sch.foo INNER JOIN sch.fooFact ON foo.id = fooFact.id""";
+
+    private static final String SELECT_FROM_FOO = "select * from foo";
+
+    private static final String SELECT_FROM_FOO_RESULT = """
+            SELECT sch.foo.id /* Resolved Column*/ , sch.foo.name /* Resolved Column*/  FROM sch.foo""";
+
+    private static final List<String> AGGREGATIONS = List.of("sum", "count", "distinctcount", "avg");
+
+    @Test
+    void testName(@InjectService SqlGuardFactory sqlGuardFactory) throws Exception {
+        DatabaseCatalog databaseCatalog = schemaWithTwoTableTwoCol();
+
+        SqlGuard guard = sqlGuardFactory.create("", SCH, databaseCatalog);
+
+        String result = guard.guard(SELECT_FROM_FOO);
+
+        assertEquals(SELECT_FROM_FOO_RESULT, result);
+    }
+
+    @Test
+    void testInnerJoin(@InjectService SqlGuardFactory sqlGuardFactory) throws Exception {
+        DatabaseCatalog databaseCatalog = schemaWithTwoTableTwoCol();
+
+        SqlGuard guard = sqlGuardFactory.create("", SCH, databaseCatalog);
+
+        String result = guard.guard(SELECT_INNER_JOIN);
+        assertEquals(SELECT_INNER_JOIN_EXPECTED, result);
+    }
+
+    @Test
+    @Disabled
+    void testInnerJoin1(@InjectService SqlGuardFactory sqlGuardFactory) throws Exception {
+        DatabaseCatalog databaseCatalog = schemaWithTwoTableTwoCol();
+
+        SqlGuard guard = sqlGuardFactory.create("", SCH, databaseCatalog);
+
+        String result = guard.guard(SELECT_INNER_JOIN_C_D);
+
+        assertEquals(SELECT_INNER_JOIN_C_D_EXPECTED, result);
+    }
+
+    @Test
+    void testInnerJoin2(@InjectService SqlGuardFactory sqlGuardFactory) throws Exception {
+        DatabaseCatalog databaseCatalog = schemaWithTwoTableTwoCol();
+
+        SqlGuard guard = sqlGuardFactory.create("", SCH, databaseCatalog);
+
+        String result = guard.guard(SELECT_INNER_JOIN_D);
+
+        assertEquals(SELECT_INNER_JOIN_D_EXPECTED, result);
+    }
+
+    @Test
+    void testTripleSelect(@InjectService SqlGuardFactory sqlGuardFactory) throws Exception {
+        DatabaseCatalog databaseCatalog = schemaWithTwoTableTwoCol();
+
+        SqlGuard guard = sqlGuardFactory.create("", SCH, databaseCatalog);
+
+        String result = guard.guard(TRIPLE_SELECT_SQL);
+
+        assertEquals(TRIPLE_SELECT_SQL_EXPECTED, result);
+    }
+
+    @Test
+    void testWhere(@InjectService SqlGuardFactory sqlGuardFactory) throws Exception {
+        DatabaseCatalog databaseCatalog = schemaWithTwoTableTwoCol();
+
+        SqlGuard guard = sqlGuardFactory.create("", SCH, databaseCatalog);
+
+        String result = guard.guard(SQL_WITH_IN);
+
+        assertEquals(SQL_WITH_IN_EXPECTED, result);
+    }
+
+    @Test
+    void testAdditionalColumn(@InjectService SqlGuardFactory sqlGuardFactory) throws Exception {
+        DatabaseCatalog databaseCatalog = schemaWithOneTable2Col();
+
+        SqlGuard guard = sqlGuardFactory.create("", SCH, databaseCatalog);
+
+        String result = guard.guard(SQL_WITH_CUSTOM_COLUMN);
+
+        assertEquals(SQL_WITH_CUSTOM_COLUMN_EXPECTED, result);
+    }
+
+    @Test
+    void testUndefinedTable(@InjectService SqlGuardFactory sqlGuardFactory) throws Exception {
+
+        DatabaseCatalog databaseCatalog = schemaWithTwoTableTwoCol();
+        SqlGuard guard = sqlGuardFactory.create("", SCH, databaseCatalog);
+
+        assertThrows(UnresolvableObjectsGuardException.class, () -> guard.guard(SQL_WITH_WRONG_TABLE));
+
+    }
+
+    @Test
+    void test(@InjectService SqlGuardFactory sqlGuardFactory) throws Exception {
+        DatabaseCatalog databaseCatalog = schemaWithOneTable2Col();
+
+        SqlGuard guard = sqlGuardFactory.create("", SCH, databaseCatalog);
+
+        RuntimeException thrown = assertThrows(RuntimeException.class, () -> guard.guard(SIMPLE_SQL_WITH_WRONG_TABLE));
+        assertEquals(TABLE_FOO1_DOES_NOT_EXIST_IN_THE_GIVEN_SCHEMA_SCH, thrown.getMessage());
+    }
+
+    @Test
+    void testGroup(@InjectService SqlGuardFactory sqlGuardFactory) throws Exception {
+
+        DatabaseCatalog databaseCatalog = schemaWithOneTable2Col();
+
+        SqlGuard guard = sqlGuardFactory.create("", SCH, databaseCatalog);
+
+        String result = guard.guard(SQL_WITH_GROUP);
+
+        assertEquals(SQL_WITH_GROUP_EXPECTED, result);
+    }
+
+    @Test
+    void testGroupAggregation(@InjectService SqlGuardFactory sqlGuardFactory) throws Exception {
+
+        DatabaseCatalog databaseCatalog = schemaWithOneTable2Col();
+
+        SqlGuard guard = sqlGuardFactory.create("", SCH, databaseCatalog);
+
+        for (String agg : AGGREGATIONS) {
+            String result = guard.guard(String.format(SQL_WITH_AGG, agg));
+            assertEquals(String.format(SQL_WITH_AGG_EXPECTED, agg), result);
+
+            assertThrows(UnresolvableObjectsGuardException.class,
+                    () -> guard.guard(String.format(SQL_WITH_AGG_WITH_WRONG_TABLE, agg)));
+
+            result = guard.guard(String.format(SQL_WITH_HAVING, agg, agg));
+            assertEquals(String.format(SQL_WITH_HAVING_EXPECTED, agg, agg), result);
+
+            assertThrows(UnresolvableObjectsGuardException.class,
+                    () -> guard.guard(String.format(SQL_WITH_HAVING_WRONG_TABLE, agg, agg)));
+            // TODO "select avg(foo1.id) from foo group by foo.name")" with any aggregation use wrong table
+            // "foo1". we have foo table only
+            // assertThrows(RuntimeException.class, () -> guard.guard("select avg(foo1.id) from foo group by
+            // foo.name"));
+
+            result = guard.guard(String.format(SQL_WITH_HAVING1, agg));
+            assertEquals(String.format(SQL_WITH_HAVING1_EXPECTED, agg), result);
+
+            assertThrows(UnresolvableObjectsGuardException.class,
+                    () -> guard.guard(String.format(SQL_WITH_HAVING_WRONG_TABLE1, agg)));
+            // TODO select sum(foo.id) from foo group by foo.name having foo1.name = 'tets' with any aggregation
+            // use wrong table "foo1". we have "foo" table only
+            // assertThrows(RuntimeException.class, () -> guard.guard("select count(foo.id) from foo group by
+            // foo.name having foo1.name = 'tets'"));
+
+            assertThrows(UnresolvableObjectsGuardException.class, () ->
+
+            guard.guard(String.format(SQL_WITH_HAVING_WRONG_COLUMN, agg)));
+            // TODO select sum(foo.id) from foo group by foo.name having foo.name1 = 'tets' we use wrong column
+            // name1. name1 ia absent. we have "name" column only
+            // assertThrows(RuntimeException.class, () -> guard.guard("select count(foo.id) from foo group by
+            // foo.name having foo.name1 = 'tets'"));
+
+        }
+    }
+
+    @Test
+    void testFunctions(@InjectService SqlGuardFactory sqlGuardFactory) throws Exception {
+
+        DatabaseCatalog databaseCatalog = schemaWithOneTable2Col();
+
+        SqlGuard guard = sqlGuardFactory.create("", SCH, databaseCatalog);
+
+        String result = guard.guard(SQL_WITH_FUNCTION);
+
+        assertEquals(SQL_WITH_FUNCTION_EXPECTED, result);
+
+        assertThrows(UnresolvableObjectsGuardException.class, () -> guard.guard(SQL_WITH_FUNCTION_WRONG_TABLE));
+
+        assertThrows(UnresolvableObjectsGuardException.class, () -> guard.guard(SQL_WITH_FUNCTION_WRONG_COLUMN));
+    }
+
+    private DatabaseCatalog schemaWithOneTable2Col() {
+        DatabaseColumn colIdFooTable = mock(DatabaseColumn.class);
+        when(colIdFooTable.getName()).thenReturn(ID);
+
+        DatabaseColumn colNameFooTable = mock(DatabaseColumn.class);
+        when(colNameFooTable.getName()).thenReturn(NAME);
+
+        DatabaseTable fooTable = mock(DatabaseTable.class);
+        when(fooTable.getName()).thenReturn(FOO);
+        when(fooTable.getDatabaseColumns()).thenReturn(List.of(colIdFooTable, colNameFooTable));
+
+        DatabaseSchema databaseSchema = mock(DatabaseSchema.class);
+        when(databaseSchema.getName()).thenReturn(SCH);
+        when(databaseSchema.getDatabaseTables()).thenReturn(List.of(fooTable));
+
+        DatabaseCatalog databaseCatalog = mock(DatabaseCatalog.class);
+        when(databaseCatalog.getName()).thenReturn(null);
+        when(databaseCatalog.getDatabaseSchemas()).thenReturn(List.of(databaseSchema));
+        return databaseCatalog;
+    }
+
+    private DatabaseCatalog schemaWithTwoTableTwoCol() {
+        DatabaseColumn colIdFooTable = mock(DatabaseColumn.class);
+        when(colIdFooTable.getName()).thenReturn(ID);
+
+        DatabaseColumn colNameFooTable = mock(DatabaseColumn.class);
+        when(colNameFooTable.getName()).thenReturn(NAME);
+
+        DatabaseTable fooTable = mock(DatabaseTable.class);
+        when(fooTable.getName()).thenReturn(FOO);
+        when(fooTable.getDatabaseColumns()).thenReturn(List.of(colIdFooTable, colNameFooTable));
+
+        DatabaseColumn colIdFooFactTable = mock(DatabaseColumn.class);
+        when(colIdFooFactTable.getName()).thenReturn(ID);
+
+        DatabaseColumn colValueFooFactTable = mock(DatabaseColumn.class);
+        when(colValueFooFactTable.getName()).thenReturn(VALUE);
+
+        DatabaseTable fooTableFact = mock(DatabaseTable.class);
+        when(fooTableFact.getName()).thenReturn(FOO_FACT);
+        when(fooTableFact.getDatabaseColumns()).thenReturn(List.of(colIdFooFactTable, colValueFooFactTable));
+
+        DatabaseSchema databaseSchema = mock(DatabaseSchema.class);
+        when(databaseSchema.getName()).thenReturn(SCH);
+        when(databaseSchema.getDatabaseTables()).thenReturn(List.of(fooTable, fooTableFact));
+
+        DatabaseCatalog databaseCatalog = mock(DatabaseCatalog.class);
+        when(databaseCatalog.getName()).thenReturn(null);
+        when(databaseCatalog.getDatabaseSchemas()).thenReturn(List.of(databaseSchema));
+        return databaseCatalog;
+    }
+
+}

--- a/guard/jsqltranspiler/test.bndrun
+++ b/guard/jsqltranspiler/test.bndrun
@@ -1,0 +1,77 @@
+#*******************************************************************************
+# Copyright (c)  2004 Contributors to the Eclipse Foundation
+#
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/ 
+# 
+# SPDX-License-Identifier: EPL-2.0
+#
+#   Contributors:
+#	 SmartCity Jena - initial
+#	 Stefan Bischof (bipolis.org) - initial
+#*******************************************************************************
+
+-runstartlevel: \
+	order=sortbynameversion,\
+	begin=-1
+
+-runtrace: true
+
+-tester: biz.aQute.tester.junit-platform
+
+# JaCoCo calculates test coverage
+-runpath.jacoco:\
+	org.jacoco.agent,\
+	org.jacoco.agent.rt
+
+-runvm.coverage: -javaagent:${repo;org.jacoco.agent.rt}=destfile=${target-dir}/jacoco.exec
+-runvm.base: -DbasePath=${.}
+
+-runpath.log: \
+	ch.qos.logback.classic,\
+	ch.qos.logback.core,\
+	slf4j.api
+
+-runproperties.logback:\
+	org.osgi.framework.bootdelegation=org.mockito.internal.creation.bytebuddy.inject,\
+	logback.configurationFile=${project.build.testOutputDirectory}/logback-test.xml
+
+-runsystemcapabilities: ${native_capability}
+
+-resolve.effective: active
+
+
+-runfw: org.apache.felix.framework
+
+-runee: JavaSE-21
+
+-runrequires: \
+	bnd.identity;id='${project.artifactId}-tests',\
+	bnd.identity;id='${project.artifactId}'
+
+# -runbundles is calculated by the bnd-resolver-maven-plugin
+-runbundles: \
+	ai.starlake.transpiler;version='[0.7.0,0.7.1)',\
+	json;version='[20250107.0.0,20250107.0.1)',\
+	junit-jupiter-api;version='[5.10.2,5.10.3)',\
+	junit-jupiter-engine;version='[5.10.2,5.10.3)',\
+	junit-jupiter-params;version='[5.10.2,5.10.3)',\
+	junit-platform-commons;version='[1.10.2,1.10.3)',\
+	junit-platform-engine;version='[1.10.2,1.10.3)',\
+	junit-platform-launcher;version='[1.10.2,1.10.3)',\
+	net.bytebuddy.byte-buddy;version='[1.12.16,1.12.17)',\
+	net.bytebuddy.byte-buddy-agent;version='[1.12.16,1.12.17)',\
+	net.sf.jsqlparser;version='[5.2.0,5.2.1)',\
+	org.apache.felix.scr;version='[2.2.10,2.2.11)',\
+	org.eclipse.daanse.sql.guard.api;version='[0.0.1,0.0.2)',\
+	org.eclipse.daanse.sql.guard.jsqltranspiler;version='[0.0.1,0.0.2)',\
+	org.eclipse.daanse.sql.guard.jsqltranspiler-tests;version='[0.0.1,0.0.2)',\
+	org.mockito.mockito-core;version='[4.9.0,4.9.1)',\
+	org.objenesis;version='[3.3.0,3.3.1)',\
+	org.opentest4j;version='[1.3.0,1.3.1)',\
+	org.osgi.service.component;version='[1.5.1,1.5.2)',\
+	org.osgi.test.common;version='[1.3.0,1.3.1)',\
+	org.osgi.test.junit5;version='[1.3.0,1.3.1)',\
+	org.osgi.util.function;version='[1.2.0,1.2.1)',\
+	org.osgi.util.promise;version='[1.3.0,1.3.1)'

--- a/guard/pom.xml
+++ b/guard/pom.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0"?>
+<!--
+/*********************************************************************
+* Copyright (c) 2024 Contributors to the Eclipse Foundation.
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which is available at https://www.eclipse.org/legal/epl-2.0/
+*
+* SPDX-License-Identifier: EPL-2.0
+**********************************************************************/
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.eclipse.daanse</groupId>
+    <artifactId>org.eclipse.daanse.sql</artifactId>
+    <version>${revision}</version>
+  </parent>
+  <artifactId>org.eclipse.daanse.sql.guard</artifactId>
+  <packaging>pom</packaging>
+  <modules>
+    <module>api</module>
+    <module>jsqltranspiler</module>
+  </modules>
+
+  <repositories>
+    <repository>
+      <id>jsqltranspiler-snapshots</id>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+      <url>https://s01.oss.sonatype.org/content/repositories/snapshots/</url>
+    </repository>
+  </repositories>
+
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -28,12 +28,41 @@
   <properties>
     <revision>0.0.1-SNAPSHOT</revision>
     <scm.repo.detail>org.eclipse.daanse.sql</scm.repo.detail>
+    <slf4j.version>2.0.9</slf4j.version>
+    <mockito.version>4.9.0</mockito.version>
+    <assertj.version>3.24.2</assertj.version>
+
+    <java.version>17</java.version>
+    <java.release>17</java.release>
+
+    <maven.compiler.source>${java.version}</maven.compiler.source>
+    <maven.compiler.target>${java.version}</maven.compiler.target>
   </properties>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>slf4j-api</artifactId>
+        <version>${slf4j.version}</version>
+        <scope>compile</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.mockito</groupId>
+        <artifactId>mockito-core</artifactId>
+        <version>${mockito.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.assertj</groupId>
+        <artifactId>assertj-core</artifactId>
+        <version>${assertj.version}</version>
+        <scope>test</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <modules>
-    <module>model.api</module>
-    <module>model.pojo</module>
-    <module>service.api</module>
-    <module>jsqlparser.play</module>
+    <module>guard</module>
   </modules>
 </project>


### PR DESCRIPTION
- Create `pom.xml` for `guard/api` and `guard/jsqltranspiler`
- Add `SqlGuard` and `SqlGuardFactory` interfaces
- Define `DatabaseCatalog`, `DatabaseSchema`, `DatabaseTable`, and `DatabaseColumn`
- Implement custom exceptions in `guard/api/exception`
- Add OSGi annotations in `package-info.java` files
- Implement `TranspilerSqlGuard` and `TranspilerSqlGuardFactory` classes
- Add unit tests for `SqlGuard` implementation in `jsqltranspiler` module
- Create `test.bndrun` for `jsqltranspiler` module
- Add `pom.xml` for `guard` module and update root `pom.xml`
- Set Java version to 17 and include dependencies for SLF4J, Mockito, and AssertJ